### PR TITLE
Add persistent medicine tracking and flexible dose start times

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,211 @@
+let medicines = [];
+let currentMedicine = null;
+
+function saveMedicines() {
+    localStorage.setItem('medicines', JSON.stringify(medicines));
+}
+
+function loadMedicines() {
+    const stored = localStorage.getItem('medicines');
+    medicines = stored ? JSON.parse(stored) : [];
+}
+
+function getProgress(med) {
+    let total = 0, completed = 0;
+    med.schedule.forEach(day => {
+        total += day.doses.length;
+        completed += day.doses.filter(d => d.completed).length;
+    });
+    return { total, completed };
+}
+
+document.getElementById('startDate').valueAsDate = new Date();
+
+function generateDoseTimes(dosesPerDay, firstDoseTime) {
+    const times = [];
+    if (dosesPerDay === 1) {
+        times.push(firstDoseTime || '08:00');
+    } else if (dosesPerDay === 2) {
+        times.push('08:00', '20:00');
+    } else if (dosesPerDay === 3) {
+        times.push('08:00', '14:00', '20:00');
+    } else if (dosesPerDay === 4) {
+        times.push('08:00', '12:00', '16:00', '20:00');
+    } else if (dosesPerDay === 6) {
+        times.push('08:00', '10:00', '12:00', '14:00', '16:00', '18:00');
+    }
+    return times;
+}
+
+function formatDate(date) {
+    return date.toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+function startTracking() {
+    const name = document.getElementById('medicineName').value.trim();
+    const startDate = document.getElementById('startDate').value;
+    const dosesPerDay = parseInt(document.getElementById('dosesPerDay').value);
+    const totalDays = parseInt(document.getElementById('totalDays').value);
+    const firstDoseTime = document.getElementById('firstDoseTime').value || '08:00';
+
+    if (!name || !startDate || !totalDays) {
+        alert('Please fill in all fields');
+        return;
+    }
+
+    const id = Date.now().toString();
+    const startDateObj = new Date(startDate);
+    const doseTimes = generateDoseTimes(dosesPerDay, firstDoseTime);
+
+    const schedule = [];
+    for (let day = 0; day < totalDays; day++) {
+        const currentDate = new Date(startDateObj);
+        currentDate.setDate(startDateObj.getDate() + day);
+        const daySchedule = { date: currentDate.toISOString(), doses: [] };
+        doseTimes.forEach((time, index) => {
+            if (day === 0 && time < firstDoseTime) return;
+            daySchedule.doses.push({
+                id: `${id}_day${day}_dose${index}`,
+                time,
+                completed: false
+            });
+        });
+        schedule.push(daySchedule);
+    }
+
+    currentMedicine = { id, name, startDate, dosesPerDay, totalDays, firstDoseTime, schedule };
+    medicines.push(currentMedicine);
+    saveMedicines();
+    renderHome();
+    openMedicine(id);
+}
+
+function renderHome() {
+    const list = document.getElementById('medicineList');
+    list.innerHTML = '';
+    if (medicines.length === 0) {
+        list.innerHTML = '<p style="color:#6b7280;">No medicines added yet.</p>';
+        return;
+    }
+    medicines.forEach(med => {
+        const progress = getProgress(med);
+        const item = document.createElement('div');
+        item.className = 'medicine-item';
+        item.innerHTML = `
+            <div style="flex:1;">
+                <strong>${med.name}</strong><br>
+                <small>${progress.completed}/${progress.total} doses</small>
+            </div>
+            <button class="btn btn-secondary" style="width:auto;padding:8px 12px;font-size:14px;" onclick="openMedicine('${med.id}')">Checklist</button>
+            <button class="btn btn-secondary" style="width:auto;padding:8px 12px;font-size:14px;" onclick="deleteMedicine('${med.id}')">Delete</button>
+        `;
+        list.appendChild(item);
+    });
+}
+
+function openMedicine(id) {
+    currentMedicine = medicines.find(m => m.id === id);
+    renderTracker();
+    showScreen('tracker');
+}
+
+function renderTracker() {
+    if (!currentMedicine) return;
+    document.getElementById('medicineTitle').textContent = currentMedicine.name;
+    const scheduleContainer = document.getElementById('doseSchedule');
+    scheduleContainer.innerHTML = '';
+    currentMedicine.schedule.forEach(day => {
+        const dayElement = document.createElement('div');
+        dayElement.className = 'day-section';
+        const completedDoses = day.doses.filter(d => d.completed).length;
+        const totalDoses = day.doses.length;
+        dayElement.innerHTML = `
+            <div class="day-header">
+                <span>${formatDate(new Date(day.date))}</span>
+                <span class="day-progress">${completedDoses}/${totalDoses}</span>
+            </div>
+        `;
+        day.doses.forEach(dose => {
+            const doseElement = document.createElement('div');
+            doseElement.className = `dose-item ${dose.completed ? 'completed' : ''}`;
+            doseElement.innerHTML = `
+                <input type="checkbox" class="dose-checkbox" ${dose.completed ? 'checked' : ''} onchange="toggleDose('${dose.id}')">
+                <span class="dose-time">${dose.time}</span>
+            `;
+            dayElement.appendChild(doseElement);
+        });
+        scheduleContainer.appendChild(dayElement);
+    });
+    updateProgress();
+}
+
+function toggleDose(doseId) {
+    if (!currentMedicine) return;
+    for (let day of currentMedicine.schedule) {
+        for (let dose of day.doses) {
+            if (dose.id === doseId) {
+                dose.completed = !dose.completed;
+                break;
+            }
+        }
+    }
+    saveMedicines();
+    renderTracker();
+}
+
+function updateProgress() {
+    if (!currentMedicine) return;
+    const progress = getProgress(currentMedicine);
+    const percentage = progress.total > 0 ? (progress.completed / progress.total) * 100 : 0;
+    document.getElementById('progressText').textContent = `${progress.completed} of ${progress.total} doses taken`;
+    document.getElementById('progressFill').style.width = `${percentage}%`;
+}
+
+function deleteMedicine(id) {
+    medicines = medicines.filter(m => m.id !== id);
+    saveMedicines();
+    if (currentMedicine && currentMedicine.id === id) {
+        currentMedicine = null;
+        showScreen('home');
+    } else {
+        renderHome();
+    }
+}
+
+function prepareSetup() {
+    document.getElementById('medicineName').value = '';
+    document.getElementById('totalDays').value = '';
+    document.getElementById('startDate').valueAsDate = new Date();
+    document.getElementById('dosesPerDay').value = '1';
+    document.getElementById('firstDoseTime').value = '08:00';
+}
+
+function showScreen(screen) {
+    document.getElementById('homeScreen').classList.add('hidden');
+    document.getElementById('setupScreen').classList.add('hidden');
+    document.getElementById('trackerScreen').classList.add('hidden');
+    if (screen === 'home') {
+        renderHome();
+        document.getElementById('homeScreen').classList.remove('hidden');
+    } else if (screen === 'setup') {
+        prepareSetup();
+        document.getElementById('setupScreen').classList.remove('hidden');
+    } else if (screen === 'tracker') {
+        document.getElementById('trackerScreen').classList.remove('hidden');
+    }
+}
+
+loadMedicines();
+renderHome();
+showScreen('home');
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+    });
+}
+console.log('Medicine Tracker PWA ready!');

--- a/index.html
+++ b/index.html
@@ -179,12 +179,16 @@
         text-decoration: line-through;
     }
 
-    .setup-screen {
-        display: block;
-    }
-
-    .tracker-screen {
-        display: none;
+    .medicine-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px;
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        margin-bottom: 8px;
+        gap: 12px;
     }
 
     .progress-summary {
@@ -229,9 +233,17 @@
             <h1>💊 Medicine Tracker</h1>
             <p>Never miss a dose</p>
         </div>
+    <!-- Home Screen -->
+    <div id="homeScreen">
+        <div class="card">
+            <h2 style="margin-bottom: 20px; color: #374151;">My Medicines</h2>
+            <div id="medicineList"></div>
+            <button class="btn" onclick="showScreen('setup')">Add Medicine</button>
+        </div>
+    </div>
 
     <!-- Setup Screen -->
-    <div id="setupScreen" class="setup-screen">
+    <div id="setupScreen" class="hidden">
         <div class="card">
             <h2 style="margin-bottom: 20px; color: #374151;">Set Up Your Medicine</h2>
             
@@ -243,6 +255,11 @@
             <div class="form-group">
                 <label for="startDate">Start Date</label>
                 <input type="date" id="startDate">
+            </div>
+
+            <div class="form-group">
+                <label for="firstDoseTime">First Dose Time</label>
+                <input type="time" id="firstDoseTime" value="08:00">
             </div>
 
             <div class="form-group">
@@ -266,7 +283,7 @@
     </div>
 
     <!-- Tracker Screen -->
-    <div id="trackerScreen" class="tracker-screen">
+    <div id="trackerScreen" class="hidden">
         <div class="progress-summary">
             <div class="progress-text" id="progressText">0 of 0 doses taken</div>
             <div class="progress-bar">
@@ -277,7 +294,7 @@
         <div class="card">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
                 <h2 id="medicineTitle" style="color: #374151;"></h2>
-                <button class="btn btn-secondary" onclick="resetApp()" style="width: auto; padding: 8px 16px; font-size: 14px;">New Medicine</button>
+                <button class="btn btn-secondary" onclick="showScreen('home')" style="width: auto; padding: 8px 16px; font-size: 14px;">Home</button>
             </div>
             
             <div id="doseSchedule" class="dose-grid"></div>
@@ -285,177 +302,7 @@
     </div>
 </div>
 
-<script>
-    let medicineData = {
-        name: '',
-        startDate: '',
-        dosesPerDay: 1,
-        totalDays: 1,
-        schedule: []
-    };
-
-    // Set today's date as default
-    document.getElementById('startDate').valueAsDate = new Date();
-
-    function generateDoseTimes(dosesPerDay) {
-        const times = [];
-        if (dosesPerDay === 1) {
-            times.push('08:00');
-        } else if (dosesPerDay === 2) {
-            times.push('08:00', '20:00');
-        } else if (dosesPerDay === 3) {
-            times.push('08:00', '14:00', '20:00');
-        } else if (dosesPerDay === 4) {
-            times.push('08:00', '12:00', '16:00', '20:00');
-        } else if (dosesPerDay === 6) {
-            times.push('08:00', '10:00', '12:00', '14:00', '16:00', '18:00');
-        }
-        return times;
-    }
-
-    function formatDate(date) {
-        return date.toLocaleDateString('en-US', { 
-            weekday: 'long', 
-            month: 'short', 
-            day: 'numeric' 
-        });
-    }
-
-    function startTracking() {
-        const name = document.getElementById('medicineName').value.trim();
-        const startDate = document.getElementById('startDate').value;
-        const dosesPerDay = parseInt(document.getElementById('dosesPerDay').value);
-        const totalDays = parseInt(document.getElementById('totalDays').value);
-
-        if (!name || !startDate || !totalDays) {
-            alert('Please fill in all fields');
-            return;
-        }
-
-        medicineData = {
-            name,
-            startDate,
-            dosesPerDay,
-            totalDays,
-            schedule: []
-        };
-
-        // Generate schedule
-        const startDateObj = new Date(startDate);
-        const doseTimes = generateDoseTimes(dosesPerDay);
-
-        for (let day = 0; day < totalDays; day++) {
-            const currentDate = new Date(startDateObj);
-            currentDate.setDate(startDateObj.getDate() + day);
-            
-            const daySchedule = {
-                date: currentDate,
-                doses: doseTimes.map((time, index) => ({
-                    id: `day${day}_dose${index}`,
-                    time,
-                    completed: false
-                }))
-            };
-            
-            medicineData.schedule.push(daySchedule);
-        }
-
-        renderTracker();
-        showScreen('tracker');
-    }
-
-    function renderTracker() {
-        document.getElementById('medicineTitle').textContent = medicineData.name;
-        
-        const scheduleContainer = document.getElementById('doseSchedule');
-        scheduleContainer.innerHTML = '';
-
-        medicineData.schedule.forEach((day, dayIndex) => {
-            const dayElement = document.createElement('div');
-            dayElement.className = 'day-section';
-            
-            const completedDoses = day.doses.filter(dose => dose.completed).length;
-            const totalDoses = day.doses.length;
-            
-            dayElement.innerHTML = `
-                <div class="day-header">
-                    <span>${formatDate(day.date)}</span>
-                    <span class="day-progress">${completedDoses}/${totalDoses}</span>
-                </div>
-            `;
-
-            day.doses.forEach(dose => {
-                const doseElement = document.createElement('div');
-                doseElement.className = `dose-item ${dose.completed ? 'completed' : ''}`;
-                doseElement.innerHTML = `
-                    <input type="checkbox" class="dose-checkbox" 
-                           ${dose.completed ? 'checked' : ''} 
-                           onchange="toggleDose('${dose.id}')">
-                    <span class="dose-time">${dose.time}</span>
-                `;
-                dayElement.appendChild(doseElement);
-            });
-
-            scheduleContainer.appendChild(dayElement);
-        });
-
-        updateProgress();
-    }
-
-    function toggleDose(doseId) {
-        for (let day of medicineData.schedule) {
-            for (let dose of day.doses) {
-                if (dose.id === doseId) {
-                    dose.completed = !dose.completed;
-                    renderTracker();
-                    return;
-                }
-            }
-        }
-    }
-
-    function updateProgress() {
-        let totalDoses = 0;
-        let completedDoses = 0;
-
-        medicineData.schedule.forEach(day => {
-            totalDoses += day.doses.length;
-            completedDoses += day.doses.filter(dose => dose.completed).length;
-        });
-
-        const percentage = totalDoses > 0 ? (completedDoses / totalDoses) * 100 : 0;
-        
-        document.getElementById('progressText').textContent = 
-            `${completedDoses} of ${totalDoses} doses taken`;
-        document.getElementById('progressFill').style.width = `${percentage}%`;
-    }
-
-    function resetApp() {
-        document.getElementById('medicineName').value = '';
-        document.getElementById('totalDays').value = '';
-        document.getElementById('startDate').valueAsDate = new Date();
-        document.getElementById('dosesPerDay').value = '1';
-        showScreen('setup');
-    }
-
-    function showScreen(screen) {
-        if (screen === 'setup') {
-            document.getElementById('setupScreen').classList.remove('hidden');
-            document.getElementById('trackerScreen').classList.add('hidden');
-        } else {
-            document.getElementById('setupScreen').classList.add('hidden');
-            document.getElementById('trackerScreen').classList.remove('hidden');
-        }
-    }
-
-    // Register service worker for offline capabilities
-    if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/service-worker.js');
-        });
-    }
-    console.log('Medicine Tracker PWA ready!');
-</script>
+<script src="app.js"></script>
 
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,8 @@
-const CACHE_NAME = 'med-tracker-cache-v1';
+const CACHE_NAME = 'med-tracker-cache-v2';
 const ASSETS = [
   '/',
   '/index.html',
+  '/app.js',
   '/manifest.json',
   '/icons/icon-192.svg',
   '/icons/icon-512.svg'


### PR DESCRIPTION
## Summary
- add home screen listing saved medicines with links to view dose checklists and to delete entries
- persist medicines in localStorage and allow configuring first dose time to start regimens in the evening
- cache new application script via updated service worker

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688e111b33708320885d159e61d024e5