### PR TITLE
Add package.json and robust dosing schedule generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "medi-helper",
+  "version": "1.0.0",
+  "description": "Medication schedule helper",
+  "scripts": {
+    "test": "node schedule.test.js"
+  }
+}

--- a/schedule.test.js
+++ b/schedule.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { createSchedule } = require('./app.js');
+
+function countDoses(schedule) {
+  return schedule.reduce((sum, day) => sum + day.doses.length, 0);
+}
+
+const schedule = createSchedule('test', '2024-05-01', 2, 10, '20:00');
+
+assert.strictEqual(countDoses(schedule), 20, 'Total doses should equal dosesPerDay * totalDays');
+assert.strictEqual(schedule[0].doses.length, 1, 'First day should have one dose when starting in the evening');
+assert.strictEqual(schedule[schedule.length - 1].doses.length, 1, 'Last day should contain remaining dose');
+
+console.log('All schedule tests passed');


### PR DESCRIPTION
## Summary
- add missing package.json with test script
- generate schedules by total dose count so late starts and final doses are handled
- add basic Node test validating dose count logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e147250748320a4b857f182cfe07c