### PR TITLE
Fix PM dose schedule using local start date

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,8 @@ function formatDate(date) {
 }
 
 function createSchedule(id, startDate, dosesPerDay, totalDays, firstDoseTime) {
-    const startDateObj = new Date(startDate);
+    const [year, month, dayNumber] = startDate.split('-').map(Number);
+    const startDateObj = new Date(year, month - 1, dayNumber);
     const doseTimes = generateDoseTimes(dosesPerDay, firstDoseTime);
     const totalDoses = dosesPerDay * totalDays;
     const schedule = [];

--- a/schedule.test.js
+++ b/schedule.test.js
@@ -1,3 +1,4 @@
+process.env.TZ = 'America/New_York';
 const assert = require('assert');
 const { createSchedule } = require('./app.js');
 
@@ -10,5 +11,9 @@ const schedule = createSchedule('test', '2024-05-01', 2, 10, '20:00');
 assert.strictEqual(countDoses(schedule), 20, 'Total doses should equal dosesPerDay * totalDays');
 assert.strictEqual(schedule[0].doses.length, 1, 'First day should have one dose when starting in the evening');
 assert.strictEqual(schedule[schedule.length - 1].doses.length, 1, 'Last day should contain remaining dose');
+const firstDay = new Date(schedule[0].date);
+assert.strictEqual(firstDay.getFullYear(), 2024, 'Year should match start date');
+assert.strictEqual(firstDay.getMonth() + 1, 5, 'Month should match start date');
+assert.strictEqual(firstDay.getDate(), 1, 'Day should match start date');
 
 console.log('All schedule tests passed');


### PR DESCRIPTION
## Summary
- interpret schedule start date in local time to prevent PM doses from shifting to the previous day
- add timezone-aware test to ensure first dose on selected date

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e15c49b808320bbc07a0b2b513e29