### PR TITLE
feat: add schedule options and cancel button

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                 <input type="date" id="startDate">
             </div>
 
-            <div class="form-group">
+            <div class="form-group" id="firstDoseGroup">
                 <label for="firstDoseTime">First Dose Time</label>
                 <input type="time" id="firstDoseTime" value="08:00">
             </div>
@@ -274,11 +274,22 @@
             </div>
 
             <div class="form-group">
+                <label for="scheduleType">Schedule Type</label>
+                <select id="scheduleType">
+                    <option value="timed">Specific times</option>
+                    <option value="label">AM/PM labels</option>
+                </select>
+            </div>
+
+            <div id="labelInputs" class="hidden"></div>
+
+            <div class="form-group">
                 <label for="totalDays">Number of Days</label>
                 <input type="number" id="totalDays" min="1" max="365" placeholder="e.g., 7">
             </div>
 
             <button class="btn" onclick="startTracking()">Start Tracking</button>
+            <button class="btn btn-secondary" onclick="confirmExit()" style="margin-top: 10px;">Home</button>
         </div>
     </div>
 

--- a/schedule.test.js
+++ b/schedule.test.js
@@ -6,7 +6,7 @@ function countDoses(schedule) {
   return schedule.reduce((sum, day) => sum + day.doses.length, 0);
 }
 
-const schedule = createSchedule('test', '2024-05-01', 2, 10, '20:00');
+const schedule = createSchedule('test', '2024-05-01', 2, 10, '20:00', 'timed');
 
 assert.strictEqual(countDoses(schedule), 20, 'Total doses should equal dosesPerDay * totalDays');
 assert.strictEqual(schedule[0].doses.length, 1, 'First day should have one dose when starting in the evening');
@@ -15,5 +15,9 @@ const firstDay = new Date(schedule[0].date);
 assert.strictEqual(firstDay.getFullYear(), 2024, 'Year should match start date');
 assert.strictEqual(firstDay.getMonth() + 1, 5, 'Month should match start date');
 assert.strictEqual(firstDay.getDate(), 1, 'Day should match start date');
+
+const labelSchedule = createSchedule('label', '2024-05-01', 2, 2, '08:00', 'label', ['AM', 'PM']);
+assert.strictEqual(labelSchedule[0].doses[0].time, 'AM', 'Label should be stored as time');
+assert.strictEqual(countDoses(labelSchedule), 4, 'Label schedule should respect doses per day');
 
 console.log('All schedule tests passed');


### PR DESCRIPTION
## Summary
- allow choosing between specific times or AM/PM labels when configuring medicine doses
- auto-distribute times based on first dose or use custom labels for each dose
- add Home button with unsaved warning on setup screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1fb2b6288320bbe3934184897408